### PR TITLE
set health port to listening port

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ camel:
 
 # Binding health checks to a different port
 management:
-  port: 8081
+  port: 8080
 
 # disable all management enpoints except health
 endpoints:


### PR DESCRIPTION
Knative for now, only supports health check on the same port as the queue listener